### PR TITLE
Unload TFormula v2

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -95,6 +95,8 @@ public:
       };
    };
 
+   using UnloadCallback_t = std::function<void()>;
+
    class SuspendAutoParsing {
       TInterpreter *fInterp;
       Bool_t        fPrevious;
@@ -119,7 +121,9 @@ public:
    virtual Int_t    AutoParse(const char* cls) = 0;
    virtual void     ClearFileBusy() = 0;
    virtual void     ClearStack() = 0; // Delete existing temporary values
-   virtual Bool_t   Declare(const char* code) = 0;
+   virtual Bool_t   Declare(const char* code,
+                            const UnloadCallback_t& /*preUnload*/ = UnloadCallback_t(),
+                            const UnloadCallback_t& /*postUnload*/ = UnloadCallback_t()) = 0;
    virtual void     EnableAutoLoading() = 0;
    virtual void     EndOfLineAction() = 0;
    virtual TClass  *GetClass(const std::type_info& typeinfo, Bool_t load) const = 0;
@@ -213,7 +217,9 @@ public:
    virtual const char *GetCurrentMacroName()  const {return 0;};
    virtual int    GetSecurityError() const{return 0;}
    virtual int    LoadFile(const char * /* path */) const {return 0;}
-   virtual Bool_t LoadText(const char * /* text */) const {return kFALSE;}
+   virtual Bool_t LoadText(const char * /* text */,
+                           const UnloadCallback_t& /*preUnload*/ = UnloadCallback_t(),
+                           const UnloadCallback_t& /*postUnload*/ = UnloadCallback_t()) const {return kFALSE;}
    virtual const char *MapCppName(const char*) const {return 0;}
    virtual void   SetAlloclockfunc(void (*)()) const {;}
    virtual void   SetAllocunlockfunc(void (*)()) const {;}

--- a/core/meta/src/TCling.h
+++ b/core/meta/src/TCling.h
@@ -170,7 +170,9 @@ public: // Public Interface
    Bool_t  IsAutoLoadNamespaceCandidate(const clang::NamespaceDecl* nsDecl);
    void    ClearFileBusy();
    void    ClearStack(); // Delete existing temporary values
-   Bool_t  Declare(const char* code);
+   Bool_t  Declare(const char* code,
+                   const UnloadCallback_t& preUnload = UnloadCallback_t(),
+                   const UnloadCallback_t& postUnload = UnloadCallback_t());
    void    EnableAutoLoading();
    void    EndOfLineAction();
    TClass *GetClass(const std::type_info& typeinfo, Bool_t load) const;
@@ -290,7 +292,9 @@ public: // Public Interface
    virtual const char* GetCurrentMacroName() const;
    virtual int    GetSecurityError() const;
    virtual int    LoadFile(const char* path) const;
-   virtual Bool_t LoadText(const char* text) const;
+   virtual Bool_t LoadText(const char* text,
+                           const UnloadCallback_t& preUnload = UnloadCallback_t(),
+                           const UnloadCallback_t& postUnload = UnloadCallback_t()) const;
    virtual const char* MapCppName(const char*) const;
    virtual void   SetAlloclockfunc(void (*)()) const;
    virtual void   SetAllocunlockfunc(void (*)()) const;

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -272,7 +272,8 @@ namespace cling {
     ///\param[in] withAccessControl - whether to enforce access restrictions.
     const clang::FunctionDecl* DeclareCFunction(llvm::StringRef name,
                                                 llvm::StringRef code,
-                                                bool withAccessControl);
+                                                bool withAccessControl,
+                                                Transaction** T = nullptr);
 
     ///\brief Include C++ runtime headers and definitions.
     ///
@@ -661,7 +662,8 @@ namespace cling {
     ///
     ///\returns the address of the function or 0 if the compilation failed.
     void* compileFunction(llvm::StringRef name, llvm::StringRef code,
-                          bool ifUniq = true, bool withAccessControl = true);
+                          bool ifUniq = true, bool withAccessControl = true,
+                          Transaction** T = 0);
 
     ///\brief Compile (and cache) destructor calls for a record decl. Used by ~Value.
     /// They are of type extern "C" void()(void* pObj).

--- a/interpreter/cling/include/cling/Interpreter/Transaction.h
+++ b/interpreter/cling/include/cling/Interpreter/Transaction.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Module.h"
 
+#include <functional>
 #include <memory>
 
 namespace clang {
@@ -114,6 +115,8 @@ namespace cling {
       void print(llvm::raw_ostream& Out, const clang::Preprocessor& PP) const;
     };
 
+    using UnloadCallback_t = std::function<void()>;
+
   private:
     // Intentionally use struct instead of pair because we don't need default
     // init.
@@ -158,6 +161,12 @@ namespace cling {
     ///\brief The Executor to use m_ExeUnload on.
     ///
     IncrementalExecutor* m_Exe;
+
+    ///\brief Whom to notify before unloading the JITed part of the transaction.
+    UnloadCallback_t m_BeforeUnload;
+
+    ///\brief Whom to notify after unloading the JITed part of the transaction.
+    UnloadCallback_t m_AfterUnload;
 
     ///\brief The wrapper function produced by the intepreter if any.
     ///
@@ -472,6 +481,16 @@ namespace cling {
       m_Exe = Exe;
       m_ExeUnload = H;
     }
+
+    void setOnUnload(const UnloadCallback_t& beforeUnload,
+                     const UnloadCallback_t& afterUnload) {
+      m_BeforeUnload = beforeUnload;
+      m_AfterUnload = afterUnload;
+    }
+
+    const UnloadCallback_t getBeforeUnload() const { return m_BeforeUnload; }
+    const UnloadCallback_t getAfterUnload() const { return m_AfterUnload; }
+
 
     clang::FunctionDecl* getWrapperFD() const { return m_WrapperFD; }
 

--- a/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/TransactionUnloader.cpp
@@ -100,9 +100,13 @@ namespace cling {
 
     bool Successful = true;
     if (getExecutor() && T->getModule()) {
+      if (T->getBeforeUnload())
+        T->getBeforeUnload()();
       Successful = getExecutor()->unloadFromJIT(T->getModule(),
                                                 T->getExeUnloadHandle())
         && Successful;
+      if (T->getAfterUnload())
+        T->getAfterUnload()();
 
       // Cleanup the module from unused global values.
       // if (T->getModule()) {


### PR DESCRIPTION
Not needed because `cling::IncrementalJIT` has only one `ClingMemoryManager` (i.e. one `llvm::SectionMemoryManager`) which tracks the emitted code's memory. Once `cling::Azog` and that `ClingMemoryManager` are combined we will need this, and cling will be able to free unloaded binary (code) memory.
