### PR TITLE
[llvm] Fix a compilation error in gcc-11.1.0 in C++20 mode

### DIFF
--- a/interpreter/llvm/src/include/llvm/CodeGen/LiveInterval.h
+++ b/interpreter/llvm/src/include/llvm/CodeGen/LiveInterval.h
@@ -715,7 +715,7 @@ namespace llvm {
       T *P;
 
     public:
-      SingleLinkedListIterator<T>(T *P) : P(P) {}
+      SingleLinkedListIterator(T *P) : P(P) {}
 
       SingleLinkedListIterator<T> &operator++() {
         P = P->Next;


### PR DESCRIPTION
This change fixes a compilation error if using `-std=c++20` in gcc-11.1.0 (see the diagnostic message below).
```
In file included from interpreter/llvm/src/lib/CodeGen/CalcSpillWeights.cpp:11:
interpreter/llvm/src/include/llvm/CodeGen/LiveInterval.h:718:36: error: expected ‘)’ before ‘*’ token
  718 |       SingleLinkedListIterator<T>(T *P) : P(P) {}
      |                                  ~ ^~
      |                                    )
```