### PR TITLE
[clang] Revert interface (and use) to upstream llvm13:

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/SourceManager.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/SourceManager.h
@@ -205,7 +205,7 @@ public:
   /// \param Loc If specified, is the location that invalid file diagnostics
   ///   will be emitted at.
   llvm::Optional<llvm::MemoryBufferRef>
-  getBufferOrNone(DiagnosticsEngine &Diag, const SourceManager &FM,
+  getBufferOrNone(DiagnosticsEngine &Diag, FileManager &FM,
                   SourceLocation Loc = SourceLocation()) const;
 
   /// Returns the size of the content encapsulated by this
@@ -1013,7 +1013,7 @@ public:
   getBufferOrNone(FileID FID, SourceLocation Loc = SourceLocation()) const {
     if (auto *Entry = getSLocEntryForFile(FID))
       return Entry->getFile().getContentCache().getBufferOrNone(
-          Diag, *this, Loc);
+          Diag, getFileManager(), Loc);
     return None;
   }
 

--- a/interpreter/llvm/src/tools/clang/lib/AST/ASTImporter.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/ASTImporter.cpp
@@ -9029,7 +9029,7 @@ Expected<FileID> ASTImporter::Import(FileID FromID, bool IsBuiltin) {
       // FIXME: We want to re-use the existing MemoryBuffer!
       llvm::Optional<llvm::MemoryBufferRef> FromBuf =
           Cache->getBufferOrNone(FromContext.getDiagnostics(),
-                                 FromSM, SourceLocation{});
+                                 FromFileManager, SourceLocation{});
       if (!FromBuf)
         return llvm::make_error<ImportError>(ImportError::Unknown);
 

--- a/interpreter/llvm/src/tools/clang/lib/Basic/SourceManager.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Basic/SourceManager.cpp
@@ -101,7 +101,7 @@ const char *ContentCache::getInvalidBOM(StringRef BufStr) {
 }
 
 llvm::Optional<llvm::MemoryBufferRef>
-ContentCache::getBufferOrNone(DiagnosticsEngine &Diag, const SourceManager &SM,
+ContentCache::getBufferOrNone(DiagnosticsEngine &Diag, FileManager &FM,
                               SourceLocation Loc) const {
   // Lazily create the Buffer for ContentCaches that wrap files.  If we already
   // computed it, just return what we have.
@@ -115,8 +115,6 @@ ContentCache::getBufferOrNone(DiagnosticsEngine &Diag, const SourceManager &SM,
   // Start with the assumption that the buffer is invalid to simplify early
   // return paths.
   IsBufferInvalid = true;
-
-  FileManager &FM = SM.getFileManager();
 
   auto BufferOrError = FM.getBufferForFile(ContentsEntry, IsFileVolatile);
 
@@ -572,7 +570,7 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
   // If this is a named pipe, immediately load the buffer to ensure subsequent
   // calls to ContentCache::getSize() are accurate.
   if (IR.ContentsEntry->isNamedPipe())
-    (void)IR.getBufferOrNone(Diag, *this, SourceLocation());
+    (void)IR.getBufferOrNone(Diag, getFileManager(), SourceLocation());
 
   return createFileIDImpl(IR, SourceFile.getName(), IncludePos, FileCharacter,
                           LoadedID, LoadedOffset);
@@ -706,7 +704,7 @@ SourceManager::createExpansionLocImpl(const ExpansionInfo &Info,
 llvm::Optional<llvm::MemoryBufferRef>
 SourceManager::getMemoryBufferForFileOrNone(const FileEntry *File) {
   SrcMgr::ContentCache &IR = getOrCreateContentCache(File->getLastRef());
-  return IR.getBufferOrNone(Diag, *this, SourceLocation());
+  return IR.getBufferOrNone(Diag, getFileManager(), SourceLocation());
 }
 
 void SourceManager::overrideFileContents(
@@ -772,7 +770,7 @@ SourceManager::getBufferDataIfLoaded(FileID FID) const {
 llvm::Optional<StringRef> SourceManager::getBufferDataOrNone(FileID FID) const {
   if (const SrcMgr::SLocEntry *Entry = getSLocEntryForFile(FID))
     if (auto B = Entry->getFile().getContentCache().getBufferOrNone(
-            Diag, *this, SourceLocation()))
+            Diag, getFileManager(), SourceLocation()))
       return B->getBuffer();
   return None;
 }
@@ -1193,7 +1191,7 @@ const char *SourceManager::getCharacterData(SourceLocation SL,
     return "<<<<INVALID BUFFER>>>>";
   }
   llvm::Optional<llvm::MemoryBufferRef> Buffer =
-      Entry.getFile().getContentCache().getBufferOrNone(Diag, *this,
+      Entry.getFile().getContentCache().getBufferOrNone(Diag, getFileManager(),
                                                         SourceLocation());
   if (Invalid)
     *Invalid = !Buffer;
@@ -1394,7 +1392,7 @@ unsigned SourceManager::getLineNumber(FileID FID, unsigned FilePos,
   /// SourceLineCache for it on demand.
   if (!Content->SourceLineCache) {
     llvm::Optional<llvm::MemoryBufferRef> Buffer =
-        Content->getBufferOrNone(Diag, *this, SourceLocation());
+        Content->getBufferOrNone(Diag, getFileManager(), SourceLocation());
     if (Invalid)
       *Invalid = !Buffer;
     if (!Buffer)
@@ -1569,7 +1567,7 @@ PresumedLoc SourceManager::getPresumedLoc(SourceLocation Loc,
   StringRef Filename;
   if (C->OrigEntry)
     Filename = C->OrigEntry->getName();
-  else if (auto Buffer = C->getBufferOrNone(Diag, *this))
+  else if (auto Buffer = C->getBufferOrNone(Diag, getFileManager()))
     Filename = Buffer->getBufferIdentifier();
 
   unsigned LineNo = getLineNumber(LocInfo.first, LocInfo.second, &Invalid);
@@ -1753,7 +1751,7 @@ SourceLocation SourceManager::translateLineCol(FileID FID,
   // If this is the first use of line information for this buffer, compute the
   // SourceLineCache for it on demand.
   llvm::Optional<llvm::MemoryBufferRef> Buffer =
-      Content->getBufferOrNone(Diag, *this);
+      Content->getBufferOrNone(Diag, getFileManager());
   if (!Buffer)
     return SourceLocation();
   if (!Content->SourceLineCache)

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriter.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriter.cpp
@@ -2008,7 +2008,7 @@ void ASTWriter::WriteSourceManagerBlock(SourceManager &SourceMgr,
         // that is required by llvm::MemoryBuffer::getMemBuffer (on
         // the reader side).
         llvm::Optional<llvm::MemoryBufferRef> Buffer =
-            Content->getBufferOrNone(PP.getDiagnostics(), PP.getSourceManager());
+            Content->getBufferOrNone(PP.getDiagnostics(), PP.getFileManager());
         StringRef Name = Buffer ? Buffer->getBufferIdentifier() : "";
         Stream.EmitRecordWithBlob(SLocBufferAbbrv, Record,
                                   StringRef(Name.data(), Name.size() + 1));
@@ -2022,7 +2022,7 @@ void ASTWriter::WriteSourceManagerBlock(SourceManager &SourceMgr,
         // Include the implicit terminating null character in the on-disk buffer
         // if we're writing it uncompressed.
         llvm::Optional<llvm::MemoryBufferRef> Buffer =
-            Content->getBufferOrNone(PP.getDiagnostics(), PP.getSourceManager());
+            Content->getBufferOrNone(PP.getDiagnostics(), PP.getFileManager());
         if (!Buffer)
           Buffer = llvm::MemoryBufferRef("<<<INVALID BUFFER>>>", "");
         StringRef Blob(Buffer->getBufferStart(), Buffer->getBufferSize() + 1);


### PR DESCRIPTION
This was a diff we carried around without functional changes.